### PR TITLE
add 'use strict' to the file to work on old Node version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 
 const validBuildTrigger = ['after-emit', 'done', 'failed'];


### PR DESCRIPTION
I found an issue that this plugin cannot work on Node js older version (<5) because of use strict mode. So I gonna add 'use strict' in index.js then we can use it on every Node version. Thanks so much!
