### PR TITLE
Use less strict mode for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,18 +30,18 @@
   },
   "homepage": "https://github.com/iGitScor/webpack-content-replacer-plugin#readme",
   "devDependencies": {
-    "all-contributors-cli": "4.0.x",
-    "codecov": "1.0.x",
-    "eslint": "3.16.x",
-    "eslint-config-airbnb": "14.1.x",
-    "eslint-plugin-import": "2.2.x",
-    "eslint-plugin-jsx-a11y": "4.0.x",
-    "eslint-plugin-react": "6.10.x",
-    "expect.js": "0.3.x",
-    "istanbul": "0.4.x",
-    "mocha": "3.2.x",
-    "webpack": "1.13",
-    "webpack-mock": "0.1.x"
+    "all-contributors-cli": "^4.0.1",
+    "codecov": "^2.1.0",
+    "eslint": "^3.18.0",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.1",
+    "expect.js": "^0.3.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0",
+    "webpack": "^1.14.0",
+    "webpack-mock": "^0.1.1"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
# Pull request

## Proposal
### What kind of change does this PR introduce?
This PR updates dev dependencies in package.json in less strict mode

### Did you add tests for your changes?
No
### Summary
The dependencies in less strict mode will enable the contributors to use more recent versions of the dependencies whilst guarding against updating major version of the dependencies which might have a higher chance of breaking the existing implementation. 

The dev dependencies now uses Caret Ranges (example: ^1.2.3). This allows changes that do not modify the left-most non-zero digit in the [major, minor, patch] tuple. This allows patch and minor updates for versions 1.0.0 and above, patch updates for versions 0.X >=0.1.0, and no updates for versions 0.0.X. 

### Other information
This PR addresses the issue https://github.com/iGitScor/webpack-content-replacer-plugin/issues/31
The dependency format details can be found here: https://docs.npmjs.com/misc/semver
